### PR TITLE
eCP → OMOP measurement mapping (+ triple-schema design)

### DIFF
--- a/ECP_CONCEPT_MAPPING_SCOPE.md
+++ b/ECP_CONCEPT_MAPPING_SCOPE.md
@@ -1,0 +1,60 @@
+# Scope: eCP → Standard OMOP Concept Mapping (enables domain-driven routing)
+
+**Status:** scoping (not yet implemented). **Why:** the decision in `ECP_OMOP_MAPPING.md` is
+*domain-driven, Measurement-default*. True domain-driven routing — and populating
+`measurement_concept_id` / `value_as_concept_id` — requires mapping eCP items and their coded
+answers to **standard OMOP concepts** and reading each concept's `domain_id`. That mapping does
+not exist in the repo yet; today we default everything to `measurement` with `concept_id = 0`.
+
+## The gap (what's missing today)
+
+- The mapping spec's `concept_id` values (e.g. `442`) are **NAACCR row ids, not standard OMOP
+  concept_ids**; `concept_code` is the NAACCR field name; the field labeled `domain_id` actually
+  holds the **NAACCR data type** (`DIGITS`/`TEXT`/`DATE`…), not the OMOP domain.
+- The C# importer / PhenoML mapper write `measurement_concept_id = 0` and `value_as_concept_id =
+  null` (TODO markers in code).
+- The SQL Server ETL already *assumes* `cap.NAACCR_CONCEPT_MAP` (item→concept) and
+  `cap.NAACCR_VALUE_CONCEPT_MAP` (answer code→value concept) exist — those maps are the shape we need
+  everywhere.
+
+## Deliverables
+
+1. **Item → standard concept map**: `(CAP eCC code | NAACCR item_num) → standard concept_id +
+   domain_id + standard_concept`. Sourced from the OHDSI NAACCR vocabulary (Athena) and CAP eCC ↔
+   LOINC/SNOMED crosswalks. Mirrors `cap.NAACCR_CONCEPT_MAP`.
+2. **Answer-value → concept map**: `(item, answer code) → value concept_id`. Mirrors
+   `cap.NAACCR_VALUE_CONCEPT_MAP`. Drives `value_as_concept_id` for coded answers.
+3. **Real OMOP domain in the spec**: add an `omop_domain_id` field (distinct from the NAACCR data
+   type) to `naaccr_omop_extension_mapping_spec.json` via `convert_naaccr_omop_maps.py`; consider
+   renaming the existing `domain_id` field to `naaccr_data_type` to end the confusion.
+4. **Wire routing + concept population** into all paths:
+   - importer/mapper/ETL look up the item concept + `domain_id`; route by domain (Measurement
+     default; Observation-domain minority → observation); populate
+     `measurement_concept_id`/`observation_concept_id` and `value_as_concept_id`.
+   - unmapped items keep the default (Measurement, `concept_id = 0`) and are reported, not dropped.
+
+## Sources / dependencies
+- OHDSI **NAACCR vocabulary** (Athena) — NAACCR variable + value concepts, with domains.
+- CAP **eCC**/eCP code system ↔ LOINC/SNOMED crosswalk (CAP-provided where available).
+- Existing SQL Server `cap.NAACCR_CONCEPT_MAP` / `cap.NAACCR_VALUE_CONCEPT_MAP` table shapes and
+  `ssdi_3nf.sql` dictionary as the data model to reuse.
+
+## Phasing
+1. Load/stage the NAACCR standard-concept vocabulary; build the item concept map for the eCP
+   templates in scope first (Adrenal, then Breast/Appendix).
+2. Build the value-set (answer) concept maps for those templates.
+3. Add `omop_domain_id` to the spec + converter; regenerate.
+4. Flip importer/mapper/ETL from blanket-Measurement to domain-driven; populate concept ids.
+5. Backfill / re-import; validate counts by domain.
+
+## Open questions
+- Vocabulary source + licensing, and refresh cadence (NAACCR releases).
+- Which eCP templates to map first, and coverage target before flipping to domain-driven.
+- Handling of items with no standard concept (stay Measurement `concept_id = 0`, flagged).
+- Confirm whether the 3-schema architecture (`database/SCHEMA_ARCHITECTURE.md`) lands before or
+  after this — the concept maps belong in the `naaccr` schema under that design.
+
+## Effort (rough)
+Vocabulary load + item/value maps for one template: small–medium. Spec/converter `omop_domain_id`:
+small. Wiring all four paths to domain-driven + concept population: medium. Full template coverage:
+ongoing, data-entry-bound.

--- a/ECP_MVP_README.md
+++ b/ECP_MVP_README.md
@@ -10,8 +10,15 @@ This implementation provides a proof of concept for importing Elective Case Pre-
 
 **Enhanced OMOP Measurement Table**
 
+- eCP synoptic Q&A defaults to the OMOP `measurement` table — each item is a
+  qualitative or quantitative result of a standardized pathology activity.
+  Numeric answers use `value_as_number`, coded answers use `value_as_concept_id`
+  (with the human-readable text in `value_source_value`). Domain-driven routing is
+  the future refinement. See `ECP_OMOP_MAPPING.md`.
 - Extended the standard OMOP `measurement` table with SDC-specific columns
-- Added fields for template instance GUID, question identifiers, response values, and metadata
+  (PostgreSQL); SQLite links via the `sdc_form_answer` table.
+- Each synoptic report becomes one OMOP `note` row; every measurement references it
+  through `measurement_event_id` (a single-report anchor).
 - Maintains full OMOP CDM v5.4 compliance while supporting ECP data
 
 **New SDC Template Instance Table**
@@ -61,9 +68,14 @@ CREATE TABLE measurement (
     person_id integer NOT NULL,
     measurement_concept_id integer NOT NULL,
     measurement_date date NOT NULL,
+    value_as_number NUMERIC NULL,    -- numeric answers (tumor size, weight, ...)
+    value_as_concept_id integer NULL, -- coded (CWE) answer concept
+    value_source_value varchar(50) NULL, -- raw / human-readable answer
+    measurement_event_id integer NULL,        -- -> note.note_id (report anchor)
+    meas_event_field_concept_id integer NULL,
     -- ... other standard fields ...
 
-    -- SDC-specific columns for ECP data
+    -- SDC-specific columns for ECP data (PostgreSQL)
     sdc_template_instance_guid varchar(255) NULL,
     sdc_question_identifier varchar(255) NULL,
     sdc_response_value TEXT NULL,
@@ -237,7 +249,7 @@ This will:
 
 1. Create a test database
 2. Import the sample NAACCR V2 message
-3. Display template instances and measurements
+3. Display template instances and measurements (linked to the report NOTE)
 4. Show data statistics and sample records
 
 ## Support

--- a/ECP_OMOP_MAPPING.md
+++ b/ECP_OMOP_MAPPING.md
@@ -1,0 +1,81 @@
+# eCP → OMOP Mapping
+
+**Status:** implemented. **Scope:** how CAP Electronic Cancer Protocol (eCP) synoptic
+report questions and answers are mapped into OMOP CDM v5.4.
+
+## Decision
+
+**eCP synoptic Q&A defaults to the OMOP `measurement` table.** Each synoptic item is a
+**qualitative or quantitative result of a standardized pathology activity** (the pathologic
+examination) — which is the OMOP definition of a Measurement:
+
+> *"Measurements differ from Observations in that they require a standardized test or some other
+> activity to generate a quantitative or qualitative result."* — OMOP CDM 5.4
+
+This also matches the established OHDSI NAACCR vocabulary, where NAACCR items are predominantly
+**Measurement-domain** concepts with the coded answer carried in `value_as_concept_id`.
+
+### The rule is domain-driven (Measurement is the default)
+
+The authoritative determinant is the **`domain_id` of the mapped standard concept**, not the
+answer's datatype. Practically:
+
+- **Result-bearing synoptic items** (tumor size, grade, stage, margins, LVI, node status,
+  histologic type…) → **`measurement`**. This is the bulk of a report and the default.
+- A **minority of contextual items** whose mapped concept is Observation-domain → `observation`.
+- Some items legitimately map elsewhere (e.g. Procedure, Specimen) — out of scope here.
+
+Until eCP items are mapped to standard concepts (see the scope doc below), we **default
+everything to `measurement`**; domain-driven splitting is the follow-up once `domain_id` is readable.
+
+## Value-column mapping (measurement has no `value_as_string`)
+
+| HL7 OBX-2 | OMOP measurement column | sample |
+|---|---|---|
+| `CWE` (coded) | `value_as_concept_id` (TODO until vocab) + human text in `value_source_value` | `2122…Adrenalectomy, total` |
+| `NM` (numeric) | `value_as_number` + `unit_source_value` / `unit_concept_id` | `10 cm`, `156 g` |
+| `ST` (text) | `value_source_value` | "specify" text |
+
+The question maps to `measurement_concept_id` (TODO until vocab), with the raw item in
+`measurement_source_value`. The report narrative/comment goes to the NOTE (below).
+
+## Single-report reference (OMOP-native)
+
+Each synoptic report (the HL7 `OBR` segment, LOINC `60568-3`, accession e.g. `15SL-2`) becomes:
+
+- one row in **`sdc_template_instance_ecp`** carrying the OBR `report_accession`/`report_loinc`; and
+- one OMOP **`note`** row holding the report narrative.
+
+Every measurement from the report sets **`measurement_event_id = note.note_id`** and
+**`meas_event_field_concept_id`** = the CDM field concept for `note.note_id`. The
+`measurement → sdc_form_answer → template_instance → sdc_template_instance_ecp` FK chain remains as
+the repo-native reference. Within a report, a question's sub-answers (unit + value, coded pick +
+"specify" text — grouped by HL7 OBX-4) link via `sdc_form_answer.parent_form_answer_id`.
+
+### Re-import / duplicates
+Re-importing the same report is **never deduped** — rows are always inserted, and collisions are
+**flagged**: `sdc_template_instance_ecp.is_duplicate_accession = 1` with `first_seen_ecp_id`
+pointing to the earliest row with that accession.
+
+## What this means in each path
+
+| Area | Behavior |
+|---|---|
+| C# importer (`ImportNaaccrVolV.cs`) | all answers → `WriteMeasurementLinkedToFormAnswer`; one NOTE per report; OBX-4 grouping; duplicate flagging |
+| `measurement` (SQLite FK / PostgreSQL `sdc_*` columns) | carries the SDC linkage; `observation` keeps the linkage too for the future domain-driven minority |
+| SQL Server ETL | all staged items → `measurement` (`value_as_concept_id`/`value_as_number`/`value_source_value`), `measurement_event_id` → NOTE, episode_event link |
+| PhenoML mapper | measurement-default; Observation-domain items → observation; both anchor to the NOTE |
+| Mapping spec | `omop_table` reflects the workbook (mostly MEASUREMENT); domain accuracy comes from the concept-mapping work |
+
+## Follow-ups
+- **Concept mapping** (scoped in `ECP_CONCEPT_MAPPING_SCOPE.md`): map eCP items + coded answers to
+  standard OMOP concepts so `domain_id` can drive routing and `measurement_concept_id` /
+  `value_as_concept_id` get populated.
+- Confirm the `note.note_id` field concept_id (used `1147289`) and a synoptic-report
+  `note_class_concept_id` against the loaded vocabulary.
+- Resolve the `MEASUREMENT + CONDITION_OCCURRENCE` combo rows in the spec with the working group.
+
+## Verification
+After importing `sample_data/naaccr_v2/obx-Adrenal.hl7`: eCP items land in `measurement` (the 2 NM
+items carry `value_as_number`; coded items carry `value_source_value`), 1 `note` whose
+`note_source_value` is the OBR accession, and all measurements share that one `measurement_event_id`.

--- a/SdcCdmLib/SdcCdm/ISdcCdm.cs
+++ b/SdcCdmLib/SdcCdm/ISdcCdm.cs
@@ -199,8 +199,17 @@ public interface ISdcCdm
         string? report_template_version_id = null,
         string? tumor_site = null,
         string? procedure_type = null,
-        string? specimen_laterality = null
+        string? specimen_laterality = null,
+        // Synoptic report identifiers (OBR segment) + re-import collision flagging
+        string? report_accession = null,
+        string? report_loinc = null,
+        bool is_duplicate_accession = false,
+        long? first_seen_ecp_id = null
     );
+
+    // Returns the earliest sdc_template_instance_ecp_id that already has this
+    // OBR accession, or null if none. Used to flag (not dedup) re-imports.
+    public long? FindFirstSdcTemplateInstanceEcpByAccession(string report_accession);
 
     // Legacy helper used by older importers. Implementations may internally
     // create an sdc_form_answer and write to either measurement or observation,
@@ -253,20 +262,30 @@ public interface ISdcCdm
         string? sdc_comments = null
     );
 
-    // 2) Write OMOP Measurement row linked to SDC form answer
+    // 2) Write OMOP Measurement row linked to SDC form answer.
+    // eCP synoptic Q&A defaults to MEASUREMENT — each item is a qualitative or
+    // quantitative result of a standardized pathology activity. See ECP_OMOP_MAPPING.md.
+    // Coded answers -> value_as_concept_id (+ human text in value_source_value);
+    // numeric -> value_as_number; text -> value_source_value. measurement_event_id /
+    // meas_event_field_concept_id link the row back to its synoptic-report NOTE row.
     public long WriteMeasurementLinkedToFormAnswer(
         long person_id,
         long measurement_concept_id,
         DateTime measurement_date,
         long measurement_type_concept_id,
         double? value_as_number = null,
+        long? value_as_concept_id = null,
+        string? value_source_value = null,
         long? unit_concept_id = null,
         string? unit_source_value = null,
         string? measurement_source_value = null,
-        long sdc_form_answer_id = 0
+        long sdc_form_answer_id = 0,
+        long? measurement_event_id = null,
+        long? meas_event_field_concept_id = null
     );
 
-    // 3) Write OMOP Observation row linked to SDC form answer
+    // 3) Write OMOP Observation row linked to SDC form answer. Used for the (future,
+    // domain-driven) minority of eCP items whose mapped concept is Observation-domain.
     public long WriteObservationLinkedToFormAnswer(
         long person_id,
         long observation_concept_id,
@@ -278,7 +297,27 @@ public interface ISdcCdm
         long? unit_concept_id = null,
         string? unit_source_value = null,
         string? observation_source_value = null,
-        long sdc_form_answer_id = 0
+        long sdc_form_answer_id = 0,
+        long? observation_event_id = null,
+        long? obs_event_field_concept_id = null
+    );
+
+    // 3) Write an OMOP Note row (one per synoptic report) used as the
+    // single-report anchor that observations reference via observation_event_id.
+    public long WriteNote(
+        long person_id,
+        DateTime note_date,
+        long note_type_concept_id,
+        long note_class_concept_id,
+        string note_text,
+        string? note_title = null,
+        long encoding_concept_id = 0,
+        long language_concept_id = 0,
+        long? provider_id = null,
+        long? visit_occurrence_id = null,
+        string? note_source_value = null,
+        long? note_event_id = null,
+        long? note_event_field_concept_id = null
     );
 
     public record SdcTemplateInstanceEcpRecord(

--- a/SdcCdmLib/SdcCdm/ImportNaaccrVolV.cs
+++ b/SdcCdmLib/SdcCdm/ImportNaaccrVolV.cs
@@ -111,6 +111,11 @@ public static class NAACCRVolVImporter
             ErrorCallback($"Unknown report type: {report_type}");
         }
 
+        // Synoptic report identifiers from OBR: OBR-3 is the filler order number /
+        // accession (durable real-world report key); OBR-4 carries the report LOINC.
+        var report_accession = (get_field(obr_segment_fields, 3) ?? string.Empty).Split('^')[0];
+        var report_loinc = report_type_code;
+
         // Extract person data
         var person_source_value = get_field(pid_segment_fields, 3);
         var person_name = get_field(pid_segment_fields, 5);
@@ -303,19 +308,71 @@ public static class NAACCRVolVImporter
         // Generate template instance GUID
         var template_instance_guid = Guid.NewGuid().ToString();
 
+        // Re-import policy: never dedup — always insert — but flag collisions so duplicate
+        // synoptic reports (same OBR accession) are queryable. See ECP_OMOP_MAPPING.md.
+        long? first_seen_ecp_id = string.IsNullOrEmpty(report_accession)
+            ? null
+            : sdcCdm.FindFirstSdcTemplateInstanceEcpByAccession(report_accession);
+        bool is_duplicate_accession = first_seen_ecp_id != null;
+        if (is_duplicate_accession)
+        {
+            Console.WriteLine(
+                $"Duplicate synoptic report accession '{report_accession}' (first seen ECP id {first_seen_ecp_id}); inserting and flagging."
+            );
+        }
+
+        // Gather the report narrative (the CAP eCC comment item) for the synoptic-report NOTE.
+        var report_narrative = "";
+        foreach (var seg in obx_segments)
+        {
+            var f = seg.Split('|');
+            var oid = get_field(f, 3);
+            if (oid.Contains("2168.1000043") || oid.Contains("Comment"))
+            {
+                report_narrative = get_field(f, 5);
+                break;
+            }
+        }
+
         // Create SDC template instance for ECP data (ECP metadata table)
         var template_instance_ecp_id = sdcCdm.WriteSdcTemplateInstanceEcp(
             template_name: template_id,
             template_version: template_version,
             template_instance_guid: template_instance_guid,
             person_id: personId,
+            report_text: report_narrative,
             report_template_source: template_source,
             report_template_id: template_id,
             report_template_version_id: template_version,
             tumor_site: tumor_site,
             procedure_type: procedure_type,
-            specimen_laterality: specimen_laterality
+            specimen_laterality: specimen_laterality,
+            report_accession: report_accession,
+            report_loinc: report_loinc,
+            is_duplicate_accession: is_duplicate_accession,
+            first_seen_ecp_id: first_seen_ecp_id
         );
+
+        // Create one OMOP NOTE row per synoptic report. Every observation parsed below
+        // references this note via observation_event_id, giving a single-report anchor.
+        var note_text = string.IsNullOrWhiteSpace(report_narrative)
+            ? $"Synoptic report {template_id} {template_version}".Trim()
+            : report_narrative;
+        long noteId = sdcCdm.WriteNote(
+            person_id: personId ?? 0,
+            note_date: DateTime.Now.Date,
+            note_type_concept_id: 32817, // EHR
+            note_class_concept_id: 0, // TODO: map synoptic report LOINC 60568-3 to a Note Class concept
+            note_text: note_text,
+            note_title: $"Synoptic Report {template_id}",
+            note_source_value: report_accession
+        );
+        // CDM field concept for note.note_id (TODO: confirm against loaded vocabulary).
+        const long NoteNoteIdFieldConceptId = 1147289;
+
+        // Track OBX-4 sub-ids so a question's sub-answers ("specify" text, unit + value)
+        // link back to their parent form answer via parent_form_answer_id.
+        var obx4ToFormAnswerId = new Dictionary<string, long>();
 
         // Also create a minimal template_instance row to satisfy sdc_form_answer FK to template_instance
         long templatesdc_fk;
@@ -419,10 +476,23 @@ public static class NAACCRVolVImporter
                     break;
             }
 
+            // Resolve OBX-4 sub-id grouping: the first OBX with a given sub-id is the
+            // parent question; later OBX with the same sub-id (unit + value, or
+            // coded pick + "specify" text) link to it via parent_form_answer_id.
+            var obx4_key = (obx4_value_raw ?? string.Empty)
+                .TrimStart('+')
+                .Split('.')[0]
+                .Trim();
+            long? parent_form_answer_id =
+                !string.IsNullOrEmpty(obx4_key)
+                && obx4ToFormAnswerId.TryGetValue(obx4_key, out var parentId)
+                    ? parentId
+                    : null;
+
             // Create SDC form-answer metadata row
             var sdc_form_answer_id = sdcCdm.WriteSdcFormAnswer(
                 template_instance_id: template_instance_id,
-                parent_form_answer_id: null,
+                parent_form_answer_id: parent_form_answer_id,
                 section_sdcid: null,
                 section_guid: null,
                 question_text: question_text,
@@ -439,41 +509,36 @@ public static class NAACCRVolVImporter
                 sdc_comments: null
             );
 
-            if (response_type == "numeric")
+            // Register the first form answer for this OBX-4 sub-id as the parent.
+            if (!string.IsNullOrEmpty(obx4_key) && parent_form_answer_id == null)
             {
-                // Write a measurement linked to the SDC form answer
-                _ = sdcCdm.WriteMeasurementLinkedToFormAnswer(
-                    person_id: personId ?? 0,
-                    measurement_concept_id: 0, // TODO: map LOINC to OMOP concept
-                    measurement_date: DateTime.Now.Date,
-                    measurement_type_concept_id: 32856, // Laboratory measurement
-                    value_as_number: numeric_value,
-                    unit_concept_id: null,
-                    unit_source_value: obx_units,
-                    measurement_source_value: obx_observation_id,
-                    sdc_form_answer_id: sdc_form_answer_id
-                );
+                obx4ToFormAnswerId[obx4_key] = sdc_form_answer_id;
             }
-            else
-            {
-                // Write an observation linked to the SDC form answer
-                _ = sdcCdm.WriteObservationLinkedToFormAnswer(
-                    person_id: personId ?? 0,
-                    observation_concept_id: 0, // TODO: map coded values to OMOP concept when available
-                    observation_date: DateTime.Now.Date,
-                    observation_type_concept_id: 45905771, // Observation recorded from EHR (inserted as essential concept)
-                    value_as_number: numeric_value,
-                    // For list selections, store the human-readable text in value_as_string
-                    value_as_string: response_type == "list_selection"
-                        ? (cwe_text ?? response_value)
-                        : response_value,
-                    value_as_concept_id: null, // TODO: parse CWE to concept id
-                    unit_concept_id: null,
-                    unit_source_value: obx_units,
-                    observation_source_value: obx_observation_id,
-                    sdc_form_answer_id: sdc_form_answer_id
-                );
-            }
+
+            // eCP synoptic Q&A defaults to MEASUREMENT — each item is a qualitative or
+            // quantitative result of a standardized pathology activity (domain-driven
+            // routing is the future refinement; see ECP_OMOP_MAPPING.md). Numeric answers
+            // use value_as_number; coded (CWE) answers use value_as_concept_id (TODO until
+            // vocab) with the human-readable text preserved in value_source_value; free text
+            // uses value_source_value. Every measurement references the synoptic-report NOTE
+            // via measurement_event_id.
+            _ = sdcCdm.WriteMeasurementLinkedToFormAnswer(
+                person_id: personId ?? 0,
+                measurement_concept_id: 0, // TODO: map question (CAP eCC code) to OMOP concept when available
+                measurement_date: DateTime.Now.Date,
+                measurement_type_concept_id: 32856, // Laboratory measurement (inserted as essential concept)
+                value_as_number: numeric_value,
+                value_as_concept_id: null, // TODO: parse CWE answer code to concept id
+                value_source_value: response_type == "list_selection"
+                    ? (cwe_text ?? response_value)
+                    : response_value,
+                unit_concept_id: null,
+                unit_source_value: obx_units,
+                measurement_source_value: obx_observation_id,
+                sdc_form_answer_id: sdc_form_answer_id,
+                measurement_event_id: noteId,
+                meas_event_field_concept_id: NoteNoteIdFieldConceptId
+            );
         }
 
         Console.WriteLine(

--- a/SdcCdmLib/SdcCdmInSqlite/SdcCdmInSqlite.cs
+++ b/SdcCdmLib/SdcCdmInSqlite/SdcCdmInSqlite.cs
@@ -813,23 +813,29 @@ public class SdcCdmInSqlite : ISdcCdm
         string? report_template_version_id = null,
         string? tumor_site = null,
         string? procedure_type = null,
-        string? specimen_laterality = null
+        string? specimen_laterality = null,
+        string? report_accession = null,
+        string? report_loinc = null,
+        bool is_duplicate_accession = false,
+        long? first_seen_ecp_id = null
     )
     {
         using var cmd = connection.CreateCommand();
         cmd.CommandText =
             @"
-            INSERT INTO main.sdc_template_instance_ecp 
-            (template_name, template_version, template_lineage, template_base_uri, template_instance_guid, 
+            INSERT INTO main.sdc_template_instance_ecp
+            (template_name, template_version, template_lineage, template_base_uri, template_instance_guid,
              template_instance_version_guid, template_instance_version_uri, instance_version_date,
-             person_id, visit_occurrence_id, provider_id, report_text, report_template_source, 
+             person_id, visit_occurrence_id, provider_id, report_text, report_template_source,
              report_template_id, report_template_version_id, tumor_site, procedure_type, specimen_laterality,
+             report_accession, report_loinc, is_duplicate_accession, first_seen_ecp_id,
              created_datetime, updated_datetime)
-            VALUES 
-            (@templateName, @templateVersion, NULL, NULL, @templateInstanceGuid, 
-             NULL, NULL, NULL, @personId, @visitOccurrenceId, @providerId, @reportText, 
-             @reportTemplateSource, @reportTemplateId, @reportTemplateVersionId, @tumorSite, 
-             @procedureType, @specimenLaterality, julianday('now'), julianday('now'));
+            VALUES
+            (@templateName, @templateVersion, NULL, NULL, @templateInstanceGuid,
+             NULL, NULL, NULL, @personId, @visitOccurrenceId, @providerId, @reportText,
+             @reportTemplateSource, @reportTemplateId, @reportTemplateVersionId, @tumorSite,
+             @procedureType, @specimenLaterality, @reportAccession, @reportLoinc, @isDuplicateAccession,
+             @firstSeenEcpId, julianday('now'), julianday('now'));
             SELECT last_insert_rowid();
         ";
 
@@ -861,9 +867,27 @@ public class SdcCdmInSqlite : ISdcCdm
             "@specimenLaterality",
             specimen_laterality ?? (object)DBNull.Value
         );
+        cmd.Parameters.AddWithValue("@reportAccession", report_accession ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@reportLoinc", report_loinc ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@isDuplicateAccession", is_duplicate_accession ? 1 : 0);
+        cmd.Parameters.AddWithValue("@firstSeenEcpId", first_seen_ecp_id ?? (object)DBNull.Value);
 
         var result = cmd.ExecuteScalar();
         return result != null ? Convert.ToInt64(result) : -1;
+    }
+
+    public long? FindFirstSdcTemplateInstanceEcpByAccession(string report_accession)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText =
+            @"
+            SELECT MIN(sdc_template_instance_ecp_id)
+            FROM main.sdc_template_instance_ecp
+            WHERE report_accession = @reportAccession;
+        ";
+        cmd.Parameters.AddWithValue("@reportAccession", report_accession);
+        var result = cmd.ExecuteScalar();
+        return result == null || result == DBNull.Value ? null : Convert.ToInt64(result);
     }
 
     public long WriteMeasurementWithSdcData(
@@ -924,40 +948,22 @@ public class SdcCdmInSqlite : ISdcCdm
             sdc_comments: sdc_comments
         );
 
-        if (
-            sdc_response_type != null
-            && sdc_response_type.Equals("numeric", StringComparison.OrdinalIgnoreCase)
-        )
-        {
-            return WriteMeasurementLinkedToFormAnswer(
-                person_id: person_id,
-                measurement_concept_id: measurement_concept_id,
-                measurement_date: measurement_date,
-                measurement_type_concept_id: measurement_type_concept_id,
-                value_as_number: value_as_number,
-                unit_concept_id: null,
-                unit_source_value: unit_source_value,
-                measurement_source_value: measurement_source_value,
-                sdc_form_answer_id: sdcFormAnswerId
-            );
-        }
-        else
-        {
-            // Treat as observation for coded/text
-            return WriteObservationLinkedToFormAnswer(
-                person_id: person_id,
-                observation_concept_id: measurement_concept_id, // upstream caller passes concept per item
-                observation_date: measurement_date,
-                observation_type_concept_id: 0,
-                value_as_number: value_as_number,
-                value_as_string: value_as_string,
-                value_as_concept_id: null,
-                unit_concept_id: null,
-                unit_source_value: unit_source_value,
-                observation_source_value: measurement_source_value,
-                sdc_form_answer_id: sdcFormAnswerId
-            );
-        }
+        // eCP synoptic Q&A defaults to MEASUREMENT (qualitatively/quantitatively derived
+        // from a standardized pathology activity). Numeric -> value_as_number; the
+        // human-readable answer is preserved in value_source_value. See ECP_OMOP_MAPPING.md.
+        return WriteMeasurementLinkedToFormAnswer(
+            person_id: person_id,
+            measurement_concept_id: measurement_concept_id, // upstream caller passes concept per item
+            measurement_date: measurement_date,
+            measurement_type_concept_id: measurement_type_concept_id,
+            value_as_number: value_as_number,
+            value_as_concept_id: null,
+            value_source_value: value_as_string,
+            unit_concept_id: null,
+            unit_source_value: unit_source_value,
+            measurement_source_value: measurement_source_value,
+            sdc_form_answer_id: sdcFormAnswerId
+        );
     }
 
     public long WriteSdcFormAnswer(
@@ -1035,10 +1041,14 @@ public class SdcCdmInSqlite : ISdcCdm
         DateTime measurement_date,
         long measurement_type_concept_id,
         double? value_as_number = null,
+        long? value_as_concept_id = null,
+        string? value_source_value = null,
         long? unit_concept_id = null,
         string? unit_source_value = null,
         string? measurement_source_value = null,
-        long sdc_form_answer_id = 0
+        long sdc_form_answer_id = 0,
+        long? measurement_event_id = null,
+        long? meas_event_field_concept_id = null
     )
     {
         using var cmd = connection.CreateCommand();
@@ -1046,12 +1056,12 @@ public class SdcCdmInSqlite : ISdcCdm
             @"
             INSERT INTO main.measurement (
                 person_id, measurement_concept_id, measurement_date, measurement_type_concept_id,
-                value_as_number, unit_concept_id, unit_source_value, measurement_source_value,
-                sdc_form_answer_id
+                value_as_number, value_as_concept_id, value_source_value, unit_concept_id, unit_source_value,
+                measurement_source_value, measurement_event_id, meas_event_field_concept_id, sdc_form_answer_id
             ) VALUES (
                 @person_id, @measurement_concept_id, @measurement_date, @measurement_type_concept_id,
-                @value_as_number, @unit_concept_id, @unit_source_value, @measurement_source_value,
-                @sdc_form_answer_id
+                @value_as_number, @value_as_concept_id, @value_source_value, @unit_concept_id, @unit_source_value,
+                @measurement_source_value, @measurement_event_id, @meas_event_field_concept_id, @sdc_form_answer_id
             );
             SELECT last_insert_rowid();
         ";
@@ -1061,6 +1071,14 @@ public class SdcCdmInSqlite : ISdcCdm
         cmd.Parameters.AddWithValue("@measurement_date", measurement_date);
         cmd.Parameters.AddWithValue("@measurement_type_concept_id", measurement_type_concept_id);
         cmd.Parameters.AddWithValue("@value_as_number", value_as_number ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue(
+            "@value_as_concept_id",
+            value_as_concept_id ?? (object)DBNull.Value
+        );
+        cmd.Parameters.AddWithValue(
+            "@value_source_value",
+            value_source_value ?? (object)DBNull.Value
+        );
         cmd.Parameters.AddWithValue("@unit_concept_id", unit_concept_id ?? (object)DBNull.Value);
         cmd.Parameters.AddWithValue(
             "@unit_source_value",
@@ -1069,6 +1087,14 @@ public class SdcCdmInSqlite : ISdcCdm
         cmd.Parameters.AddWithValue(
             "@measurement_source_value",
             measurement_source_value ?? (object)DBNull.Value
+        );
+        cmd.Parameters.AddWithValue(
+            "@measurement_event_id",
+            measurement_event_id ?? (object)DBNull.Value
+        );
+        cmd.Parameters.AddWithValue(
+            "@meas_event_field_concept_id",
+            meas_event_field_concept_id ?? (object)DBNull.Value
         );
         cmd.Parameters.AddWithValue("@sdc_form_answer_id", sdc_form_answer_id);
 
@@ -1087,7 +1113,9 @@ public class SdcCdmInSqlite : ISdcCdm
         long? unit_concept_id = null,
         string? unit_source_value = null,
         string? observation_source_value = null,
-        long sdc_form_answer_id = 0
+        long sdc_form_answer_id = 0,
+        long? observation_event_id = null,
+        long? obs_event_field_concept_id = null
     )
     {
         using var cmd = connection.CreateCommand();
@@ -1096,11 +1124,11 @@ public class SdcCdmInSqlite : ISdcCdm
             INSERT INTO main.observation (
                 person_id, observation_concept_id, observation_date, observation_type_concept_id,
                 value_as_number, value_as_string, value_as_concept_id, unit_concept_id, unit_source_value,
-                observation_source_value, sdc_form_answer_id
+                observation_source_value, observation_event_id, obs_event_field_concept_id, sdc_form_answer_id
             ) VALUES (
                 @person_id, @observation_concept_id, @observation_date, @observation_type_concept_id,
                 @value_as_number, @value_as_string, @value_as_concept_id, @unit_concept_id, @unit_source_value,
-                @observation_source_value, @sdc_form_answer_id
+                @observation_source_value, @observation_event_id, @obs_event_field_concept_id, @sdc_form_answer_id
             );
             SELECT last_insert_rowid();
         ";
@@ -1124,7 +1152,75 @@ public class SdcCdmInSqlite : ISdcCdm
             "@observation_source_value",
             observation_source_value ?? (object)DBNull.Value
         );
+        cmd.Parameters.AddWithValue(
+            "@observation_event_id",
+            observation_event_id ?? (object)DBNull.Value
+        );
+        cmd.Parameters.AddWithValue(
+            "@obs_event_field_concept_id",
+            obs_event_field_concept_id ?? (object)DBNull.Value
+        );
         cmd.Parameters.AddWithValue("@sdc_form_answer_id", sdc_form_answer_id);
+
+        var result = cmd.ExecuteScalar();
+        return result != null ? Convert.ToInt64(result) : -1;
+    }
+
+    public long WriteNote(
+        long person_id,
+        DateTime note_date,
+        long note_type_concept_id,
+        long note_class_concept_id,
+        string note_text,
+        string? note_title = null,
+        long encoding_concept_id = 0,
+        long language_concept_id = 0,
+        long? provider_id = null,
+        long? visit_occurrence_id = null,
+        string? note_source_value = null,
+        long? note_event_id = null,
+        long? note_event_field_concept_id = null
+    )
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText =
+            @"
+            INSERT INTO main.note (
+                person_id, note_date, note_type_concept_id, note_class_concept_id,
+                note_title, note_text, encoding_concept_id, language_concept_id,
+                provider_id, visit_occurrence_id, note_source_value,
+                note_event_id, note_event_field_concept_id
+            ) VALUES (
+                @person_id, @note_date, @note_type_concept_id, @note_class_concept_id,
+                @note_title, @note_text, @encoding_concept_id, @language_concept_id,
+                @provider_id, @visit_occurrence_id, @note_source_value,
+                @note_event_id, @note_event_field_concept_id
+            );
+            SELECT last_insert_rowid();
+        ";
+
+        cmd.Parameters.AddWithValue("@person_id", person_id);
+        cmd.Parameters.AddWithValue("@note_date", note_date);
+        cmd.Parameters.AddWithValue("@note_type_concept_id", note_type_concept_id);
+        cmd.Parameters.AddWithValue("@note_class_concept_id", note_class_concept_id);
+        cmd.Parameters.AddWithValue("@note_title", note_title ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@note_text", note_text ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@encoding_concept_id", encoding_concept_id);
+        cmd.Parameters.AddWithValue("@language_concept_id", language_concept_id);
+        cmd.Parameters.AddWithValue("@provider_id", provider_id ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue(
+            "@visit_occurrence_id",
+            visit_occurrence_id ?? (object)DBNull.Value
+        );
+        cmd.Parameters.AddWithValue(
+            "@note_source_value",
+            note_source_value ?? (object)DBNull.Value
+        );
+        cmd.Parameters.AddWithValue("@note_event_id", note_event_id ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue(
+            "@note_event_field_concept_id",
+            note_event_field_concept_id ?? (object)DBNull.Value
+        );
 
         var result = cmd.ExecuteScalar();
         return result != null ? Convert.ToInt64(result) : -1;
@@ -1286,6 +1382,36 @@ public class SdcCdmInSqlite : ISdcCdm
                 ConceptClassId = "Type Concept",
                 StandardConcept = "S",
                 ConceptCode = "EHR_obs",
+                ValidStartDate = DateTime.Parse("1970-01-01"),
+                ValidEndDate = DateTime.Parse("2099-12-31"),
+                InvalidReason = null,
+            },
+            // Note type for the synoptic-report NOTE row (one per eCP report)
+            new ConceptRecord
+            {
+                ConceptId = 32817,
+                ConceptName = "EHR",
+                DomainId = "Type Concept",
+                VocabularyId = "Type Concept",
+                ConceptClassId = "Type Concept",
+                StandardConcept = "S",
+                ConceptCode = "EHR",
+                ValidStartDate = DateTime.Parse("1970-01-01"),
+                ValidEndDate = DateTime.Parse("2099-12-31"),
+                InvalidReason = null,
+            },
+            // CDM field concept for note.note_id, used as observation.obs_event_field_concept_id
+            // when observation_event_id references the synoptic-report NOTE row.
+            // TODO: confirm the exact field concept_id against the loaded OMOP vocabulary.
+            new ConceptRecord
+            {
+                ConceptId = 1147289,
+                ConceptName = "note.note_id",
+                DomainId = "Metadata",
+                VocabularyId = "CDM",
+                ConceptClassId = "Field",
+                StandardConcept = "S",
+                ConceptCode = "note.note_id",
                 ValidStartDate = DateTime.Parse("1970-01-01"),
                 ValidEndDate = DateTime.Parse("2099-12-31"),
                 InvalidReason = null,

--- a/SdcCdmLib/SdcCdmInSqlite/TestImport.cs
+++ b/SdcCdmLib/SdcCdmInSqlite/TestImport.cs
@@ -133,25 +133,26 @@ namespace SdcCdmInSqlite
                 Console.WriteLine("CHECKING OMOP ROWS LINKED TO SDC_FORM_ANSWER");
                 Console.WriteLine(new string('=', 80));
 
+                // eCP Q&A defaults to MEASUREMENT. Each measurement links to its
+                // synoptic-report NOTE via measurement_event_id.
                 using var qaCmd = connection.CreateCommand();
                 qaCmd.CommandText =
                     @"
                     SELECT sfa.sdc_form_answer_id, sfa.question_instance_guid, sfa.question_text,
-                           m.measurement_id, m.value_as_number, m.unit_source_value,
-                           o.observation_id, o.value_as_string
+                           m.measurement_id, m.value_as_number, m.value_source_value,
+                           m.unit_source_value, m.measurement_event_id
                     FROM sdc_form_answer sfa
                     LEFT JOIN measurement m ON m.sdc_form_answer_id = sfa.sdc_form_answer_id
-                    LEFT JOIN observation o ON o.sdc_form_answer_id = sfa.sdc_form_answer_id
                     ORDER BY sfa.sdc_form_answer_id
                     LIMIT 20;
                 ";
 
                 using var qaReader = qaCmd.ExecuteReader();
                 Console.WriteLine(
-                    "AnsId | Q GUID | Q Text | MeasID | MeasVal | Units | ObsID | ObsVal"
+                    "AnsId | Q GUID | Q Text | MeasID | MeasNum | MeasVal | Units | NoteId"
                 );
                 Console.WriteLine(
-                    "------+--------+--------+--------+---------+-------+-------+-------"
+                    "------+--------+--------+--------+---------+---------+-------+-------"
                 );
                 while (qaReader.Read())
                 {
@@ -159,12 +160,12 @@ namespace SdcCdmInSqlite
                     var qGuid = qaReader.IsDBNull(1) ? "" : qaReader.GetString(1);
                     var qText = qaReader.IsDBNull(2) ? "" : qaReader.GetString(2);
                     var measId = qaReader.IsDBNull(3) ? (long?)null : qaReader.GetInt64(3);
-                    var measVal = qaReader.IsDBNull(4) ? (double?)null : qaReader.GetDouble(4);
-                    var units = qaReader.IsDBNull(5) ? "" : qaReader.GetString(5);
-                    var obsId = qaReader.IsDBNull(6) ? (long?)null : qaReader.GetInt64(6);
-                    var obsVal = qaReader.IsDBNull(7) ? "" : qaReader.GetString(7);
+                    var measNum = qaReader.IsDBNull(4) ? (double?)null : qaReader.GetDouble(4);
+                    var measVal = qaReader.IsDBNull(5) ? "" : qaReader.GetString(5);
+                    var units = qaReader.IsDBNull(6) ? "" : qaReader.GetString(6);
+                    var noteId = qaReader.IsDBNull(7) ? (long?)null : qaReader.GetInt64(7);
                     Console.WriteLine(
-                        $"{ansId} | {qGuid} | {qText} | {measId?.ToString() ?? ""} | {measVal?.ToString() ?? ""} | {units} | {obsId?.ToString() ?? ""} | {obsVal}"
+                        $"{ansId} | {qGuid} | {qText} | {measId?.ToString() ?? ""} | {measNum?.ToString() ?? ""} | {measVal} | {units} | {noteId?.ToString() ?? ""}"
                     );
                 }
             }

--- a/database/SCHEMA_ARCHITECTURE.md
+++ b/database/SCHEMA_ARCHITECTURE.md
@@ -1,0 +1,128 @@
+# Schema Architecture: NAACCR + SDC + OMOP (separation of concerns)
+
+**Status:** design (not yet implemented). **Goal:** stop bolting SDC/NAACCR extensions onto
+OMOP core. Instead, one physical database with **separate schemas per concern**, an unmodified
+OMOP CDM, and a transform that bridges them. This honors the policy already in
+`naaccr_omop/README.md`: *FKs live on the NAACCR side; do not add non-FK fields to OMOP core.*
+
+## Schemas (one database, extensible)
+
+Start with three schemas; add more later (e.g. `vocab`, `fhir`, `audit`, `etl`) without disturbing
+these. Cross-schema references use schema-qualified names within the one database.
+
+### 1. `naaccr` — NAACCR-native dictionary + captured values
+Authoritative for the NAACCR data dictionary **and** the raw captured answers.
+
+- **Dictionary / metadata** (today's `cap.*`):
+  `naaccr_item` (item_num, name, xml_id), `staging_schema`, `schema_selection_rule`,
+  `schema_item`, `schema_item_code` (value sets), `schema_item_requirement`, `registry`.
+- **Captured values — staging shape** (per the chosen model, like today's `dbo.naaccr_staging`):
+  `naaccr_value` with `person_id, episode_key, report_accession, schema_id_number, item_num,
+  value_code, value_num, value_unit_source, observation_date`. One row per answered item.
+  `report_accession` ties a row to its synoptic report (OBR accession).
+- **Concept maps**: `naaccr_concept_map` (item_num → OMOP concept), `naaccr_value_concept_map`
+  (item code → value concept).
+
+### 2. `sdc` — Structured Data Capture (form/report structure)
+The IHE-SDC layer: what the form is and which report an answer came from. **Structure only —
+no answer values** (those live in `naaccr`).
+
+- `template_sdc`, `template_item`, `template_instance`, `template_term_map`, `template_map_content`
+- `sdc_form_answer` (question/section/list-item context per item), `sdc_specimen`,
+  `observation_specimens`
+- `sdc_report` (renamed `sdc_template_instance_ecp`): the synoptic-report header — `report_accession`,
+  `report_loinc` (60568-3), template name/version, narrative, `is_duplicate_accession`,
+  `first_seen_report_id`.
+
+`sdc` ↔ `naaccr` relate by shared business keys: `(report_accession | episode_key) + item_num`.
+No hard cross-schema FK required (loose coupling); add one within-DB if desired.
+
+### 3. `omop` — vanilla OMOP CDM 5.4 (UNMODIFIED)
+Stock OHDSI DDL, dropped in unchanged. **No `sdc_*` columns, no SDC tables, no `sdc_form_answer_id`
+FK.** Upgradable by swapping the upstream DDL; ATLAS/Achilles/DQD work out of the box.
+
+## Back-reference WITHOUT a crosswalk (loose coupling)
+
+OMOP rows point back to the source using **only standard OMOP columns**:
+
+- `omop.observation.observation_source_value` = the NAACCR/CAP item code (e.g. `2129.1000043`)
+- `omop.observation.observation_source_concept_id` = mapped concept
+- `omop.observation.observation_event_id` = `omop.note.note_id`; `omop.note.note_source_value`
+  = the report accession
+- numeric → `value_as_number` (+ `unit_source_value`); coded → `value_as_concept_id`; text →
+  `value_as_string`
+
+Going from an OMOP observation back to SDC context is a **key join**, not a stored FK:
+
+```sql
+-- OMOP observation  ->  report  ->  SDC question context  ->  NAACCR dictionary
+SELECT o.observation_id, o.value_as_number, o.value_as_string,
+       sr.report_accession, sfa.question_text, ni.name AS naaccr_item_name
+FROM omop.observation o
+JOIN omop.note n            ON n.note_id = o.observation_event_id
+JOIN sdc.sdc_report sr      ON sr.report_accession = n.note_source_value
+JOIN sdc.sdc_form_answer sfa ON sfa.report_id = sr.sdc_report_id
+                            AND sfa.question_sdcid = o.observation_source_value
+JOIN naaccr.naaccr_item ni  ON CAST(ni.item_num AS TEXT) = SUBSTR(o.observation_source_value, 1, INSTR(o.observation_source_value,'.')-1);
+```
+
+## Data flow
+
+```
+HL7 V2 / NAACCR XML
+   │  (importer: parse once)
+   ├─► naaccr.naaccr_value         (raw answers, staging shape)
+   ├─► naaccr.* dictionary         (seeded/reference)
+   └─► sdc.sdc_report + sdc.sdc_form_answer + sdc.template_*   (structure + report header)
+            │
+            ▼  (bridge / transform — reads naaccr+sdc, writes standard OMOP only)
+   omop.note (1 per report)  +  omop.observation (1 per answer, observation_event_id→note)
+   omop.episode + omop.episode_event
+```
+
+Two steps: (1) ingest to `naaccr`+`sdc`; (2) transform to `omop`. The transform is the only place
+that knows both sides, and it writes vanilla OMOP.
+
+## Physical model per dialect (decide at implementation)
+
+- **PostgreSQL / SQL Server**: real `CREATE SCHEMA naaccr|sdc|omop`; schema-qualified joins are free.
+  (SQL Server already does `cap` + `dbo`.)
+- **SQLite**: no native schemas — emulate with **`ATTACH DATABASE 'naaccr.db' AS naaccr`** (one file
+  per schema, schema-qualified names + cross-schema joins work), or a single file with `naaccr_` /
+  `sdc_` / `omop_` table-name prefixes. ATTACH is the closer analog and keeps the qualified-name model.
+
+## Repo layout
+
+```
+database/
+  schemas/
+    naaccr/ddl/{sqlite,postgresql,sqlserver}/   + seed/   (dictionary, concept maps)
+    sdc/ddl/{sqlite,postgresql,sqlserver}/
+    omop/ddl/{sqlite,postgresql,sqlserver}/      (vendored upstream OHDSI CDM 5.4, unmodified)
+  etl/                                           (naaccr+sdc -> omop transform, dialect-aware)
+  build.sh                                       (create schemas in order; load seeds; run etl)
+```
+
+## Migration from today
+
+- **Delete from OMOP core**: the 14 `sdc_*` columns on `observation` (PG), the `sdc_form_answer_id`
+  ALTERs/indexes (SQLite), and any SDC tables currently created inside the OMOP DDL.
+- **Move to `sdc`**: `template_*`, `sdc_form_answer`, `sdc_specimen`, `observation_specimens`,
+  `sdc_template_instance_ecp`→`sdc_report`. Drop the duplicate `sdc_observation` answer store.
+- **Move to `naaccr`**: `cap.*` dictionary + a `naaccr_value` (staging-shape) answer table + concept maps.
+- **Keep as-is (already OMOP-native, survives untouched)**: the `note` per report and
+  `observation_event_id` linkage we just built; `observation_source_value`/`_concept_id`.
+- **C# importer**: split writes — populate `naaccr`/`sdc`, then run the bridge to emit `omop`.
+  `ISdcCdm` gains `naaccr`/`sdc` writers; the OMOP writers target vanilla columns only.
+- **Queries**: `ecp_query_examples.sql` denormalized `sdc_*` selects become key joins (example above).
+
+## Decisions locked in
+- One database, three schemas (`naaccr`, `sdc`, `omop`), extensible to more.
+- Captured values stored in NAACCR staging shape.
+- OMOP back-reference via `observation_source_value` + `observation_event_id` only — no crosswalk table.
+- Dialects chosen at implementation time.
+
+## Open questions for implementation
+- SQLite: ATTACH-per-schema vs name-prefix (affects build scripts and how the C# connection attaches).
+- Exact `naaccr_value` key (is `report_accession` always present, or fall back to `episode_key`?).
+- Whether the importer writes `omop` inline (single pass) or the bridge is a separate batch step.

--- a/database/ddl/postgresql/1_OMOPCDM_postgresql_5.4-SDC_ddl.sql
+++ b/database/ddl/postgresql/1_OMOPCDM_postgresql_5.4-SDC_ddl.sql
@@ -173,7 +173,8 @@ CREATE TABLE public.measurement (
 			value_source_value varchar(50) NULL,
 			measurement_event_id integer NULL,
 			meas_event_field_concept_id integer NULL,
-			-- SDC-specific columns for ECP data
+			-- SDC-specific columns for ECP data. eCP synoptic Q&A defaults to MEASUREMENT
+			-- (qualitatively/quantitatively derived). See ECP_OMOP_MAPPING.md.
 			sdc_template_instance_guid varchar(255) NULL,
 			sdc_question_identifier varchar(255) NULL,
 			sdc_response_value TEXT NULL,
@@ -651,6 +652,12 @@ CREATE TABLE public.sdc_template_instance_ecp (
 			tumor_site varchar(255) NULL,
 			procedure_type varchar(255) NULL,
 			specimen_laterality varchar(255) NULL,
+			-- Synoptic report identifiers from the OBR segment (single-report anchor)
+			report_accession varchar(255) NULL,
+			report_loinc varchar(50) NULL,
+			-- Re-import collision flagging (no dedup: always insert, but flag duplicates)
+			is_duplicate_accession integer NOT NULL DEFAULT 0,
+			first_seen_ecp_id integer NULL,
 			-- Metadata fields
 			created_datetime TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 			updated_datetime TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/database/ddl/sqlite/1_OMOPCDM_sqlite_5.4-SDC_ddl.sql
+++ b/database/ddl/sqlite/1_OMOPCDM_sqlite_5.4-SDC_ddl.sql
@@ -638,10 +638,19 @@ CREATE TABLE main.sdc_template_instance_ecp (
 			tumor_site TEXT NULL,
 			procedure_type TEXT NULL,
 			specimen_laterality TEXT NULL,
+			-- Synoptic report identifiers from the OBR segment (single-report anchor)
+			report_accession TEXT NULL,
+			report_loinc TEXT NULL,
+			-- Re-import collision flagging (no dedup: always insert, but flag duplicates)
+			is_duplicate_accession integer NOT NULL DEFAULT 0,
+			first_seen_ecp_id integer NULL REFERENCES sdc_template_instance_ecp(sdc_template_instance_ecp_id),
 			-- Metadata fields
 			created_datetime REAL DEFAULT (julianday('now')),
 			updated_datetime REAL DEFAULT (julianday('now')) );
--- Add SDC linkage FKs to OMOP tables after ancillary SDC table creation
+-- Add SDC linkage FKs to OMOP tables after ancillary SDC table creation.
+-- eCP synoptic Q&A defaults to MEASUREMENT (qualitatively/quantitatively derived);
+-- observation keeps the linkage too for the future domain-driven minority.
+-- See ECP_OMOP_MAPPING.md.
 ALTER TABLE main.measurement
 	ADD COLUMN sdc_form_answer_id integer NULL REFERENCES sdc_form_answer(sdc_form_answer_id);
 CREATE INDEX IF NOT EXISTS idx_measurement_sdc_form_answer_id ON measurement(sdc_form_answer_id);
@@ -649,4 +658,5 @@ CREATE INDEX IF NOT EXISTS idx_measurement_sdc_form_answer_id ON measurement(sdc
 ALTER TABLE main.observation
 	ADD COLUMN sdc_form_answer_id integer NULL REFERENCES sdc_form_answer(sdc_form_answer_id);
 CREATE INDEX IF NOT EXISTS idx_observation_sdc_form_answer_id ON observation(sdc_form_answer_id);
+CREATE INDEX IF NOT EXISTS idx_ecp_report_accession ON sdc_template_instance_ecp(report_accession);
 COMMIT;

--- a/database/ddl/sqlserver/naaccr_to_omop_etl.sql
+++ b/database/ddl/sqlserver/naaccr_to_omop_etl.sql
@@ -2,8 +2,15 @@
   NAACCR → OMOP CDM v5.4 ETL Scaffolding (SQL Server)
 
   Goal
-  - Materialize NAACCR items as OMOP Observation/Measurement records
+  - Materialize NAACCR items as OMOP Measurement records (eCP synoptic Q&A defaults to
+    MEASUREMENT — each item is a qualitative or quantitative result of a standardized
+    pathology activity; coded answers use value_as_concept_id, numeric uses value_as_number,
+    text uses value_source_value). Domain-driven routing is the future refinement.
+    See ECP_OMOP_MAPPING.md.
   - Anchor all NAACCR-derived events to an Oncology Episode using EPISODE/EPISODE_EVENT
+  - Anchor each report's measurements to a single NOTE row via measurement_event_id.
+    NOTE: dbo.naaccr_staging has no synoptic-report/accession grain, so the note here
+    is per (person_id, episode_key). The HL7 V2 path carries the true per-report accession.
 
   Notes
   - This is a scaffolding script: adapt to your source case-level tables.
@@ -48,12 +55,6 @@ SELECT TOP 1
 FROM dbo.concept
 WHERE vocabulary_id = 'NAACCR2026' AND concept_code = 'NAACCR_CANCER_EPISODE';
 
-DECLARE @FIELD_OBS_ID BIGINT;
-SELECT TOP 1
-  @FIELD_OBS_ID = concept_id
-FROM dbo.concept
-WHERE vocabulary_id = 'NAACCR2026' AND concept_code = 'FIELD_OBSERVATION_ID';
-
 DECLARE @FIELD_MEAS_ID BIGINT;
 SELECT TOP 1
   @FIELD_MEAS_ID = concept_id
@@ -65,6 +66,11 @@ SELECT TOP 1
   @TYPE_NAACCR = concept_id
 FROM dbo.concept
 WHERE vocabulary_id = 'NAACCR2026' AND concept_code = 'TYPE_NAACCR_DERIVED';
+
+-- Note + observation-event linkage concepts. Literals match the HL7 V2 / PhenoML paths.
+-- TODO: confirm @FIELD_NOTE_ID (CDM field concept for note.note_id) against the vocabulary.
+DECLARE @NOTE_TYPE_EHR  BIGINT = 32817;   -- EHR note type
+DECLARE @FIELD_NOTE_ID  BIGINT = 1147289; -- note.note_id field concept
 
 ------------------------------------------------------------
 -- 1) Build/Upsert EPISODE for each (person_id, episode_key)
@@ -104,10 +110,48 @@ FROM episodes_src e
 WHERE tgt.episode_id IS NULL;
 
 ------------------------------------------------------------
--- 2) Insert NAACCR items as Observations
---    - observation_concept_id = NAACCR Item concept
---    - value_as_concept_id    = NAACCR Value concept (categorical)
+-- 1b) Build one NOTE per (person_id, episode_key) as the single-report anchor.
+--     Measurements below reference it via measurement_event_id.
+------------------------------------------------------------
+;WITH
+  notes_src
+  AS
+  (
+    SELECT ns.person_id, ns.episode_key, MIN(ns.observation_date) AS note_date
+    FROM dbo.naaccr_staging ns
+    GROUP BY ns.person_id, ns.episode_key
+  )
+INSERT INTO dbo.note
+  (
+  person_id, note_date, note_datetime, note_type_concept_id, note_class_concept_id,
+  note_title, note_text, encoding_concept_id, language_concept_id,
+  provider_id, visit_occurrence_id, note_source_value
+  )
+SELECT
+  n.person_id,
+  COALESCE(n.note_date, CAST(GETDATE() AS DATE)) AS note_date,
+  CAST(COALESCE(n.note_date, CAST(GETDATE() AS DATE)) AS DATETIME) AS note_datetime,
+  @NOTE_TYPE_EHR AS note_type_concept_id,
+  0 AS note_class_concept_id, -- TODO: map synoptic report LOINC to a Note Class concept
+  'Synoptic Report' AS note_title,
+  'Synoptic report ' + n.episode_key AS note_text,
+  0 AS encoding_concept_id,
+  0 AS language_concept_id,
+  NULL AS provider_id,
+  NULL AS visit_occurrence_id,
+  n.episode_key AS note_source_value
+FROM notes_src n
+  LEFT JOIN dbo.note tgt
+  ON tgt.person_id = n.person_id AND tgt.note_source_value = n.episode_key
+WHERE tgt.note_id IS NULL;
+
+------------------------------------------------------------
+-- 2) Insert NAACCR items as Measurements (ALL items — categorical and numeric).
+--    - measurement_concept_id = NAACCR Item concept
+--    - value_as_concept_id    = NAACCR Value concept (categorical/qualitative result)
 --    - value_as_number/unit   = numeric where applicable
+--    - value_source_value     = raw answer code/text
+--    - measurement_event_id   = the report NOTE (single-report anchor)
 ------------------------------------------------------------
 ;
 WITH
@@ -127,6 +171,7 @@ WITH
   AS
   (
     SELECT ns.person_id,
+      ns.episode_key,
       ns.item_num,
       ns.value_code,
       ns.value_num,
@@ -134,64 +179,14 @@ WITH
       ns.observation_date
     FROM dbo.naaccr_staging ns
   )
--- 2a) Categorical items → Observations
-INSERT INTO dbo.observation
-  (
-  person_id, observation_concept_id, observation_date, observation_datetime,
-  observation_type_concept_id, value_as_number, value_as_string, value_as_concept_id,
-  qualifier_concept_id, unit_concept_id, provider_id, visit_occurrence_id, visit_detail_id,
-  observation_source_value, observation_source_concept_id, unit_source_value, qualifier_source_value
-  )
-SELECT
-  i.person_id,
-  ic.item_concept_id AS observation_concept_id,
-  COALESCE(i.observation_date, CAST(GETDATE() AS DATE)) AS observation_date,
-  CAST(COALESCE(i.observation_date, CAST(GETDATE() AS DATE)) AS DATETIME) AS observation_datetime,
-  @TYPE_NAACCR AS observation_type_concept_id,
-  i.value_num AS value_as_number,
-  NULL AS value_as_string,
-  vc.value_concept_id AS value_as_concept_id,
-  NULL AS qualifier_concept_id,
-  NULL AS unit_concept_id, -- map unit_source_value to a unit_concept_id if available
-  NULL AS provider_id,
-  NULL AS visit_occurrence_id,
-  NULL AS visit_detail_id,
-  CAST(i.item_num AS NVARCHAR(50)) AS observation_source_value,
-  ic.item_concept_id AS observation_source_concept_id,
-  i.value_unit_source AS unit_source_value,
-  NULL AS qualifier_source_value
-FROM input_rows i
-  JOIN item_concepts ic
-  ON ic.item_num = i.item_num
-  LEFT JOIN value_concepts vc
-  ON vc.item_num = i.item_num AND vc.code = COALESCE(i.value_code, N'')
-WHERE i.value_num IS NULL;
--- use Observation only when no numeric value
-
-------------------------------------------------------------
--- 2b) Numeric items → Measurements
-------------------------------------------------------------
-;
-WITH
-  item_concepts_m
-  AS
-  (
-    SELECT m.item_num, m.concept_id AS item_concept_id
-    FROM cap.NAACCR_CONCEPT_MAP m
-  ),
-  input_rows_m
-  AS
-  (
-    SELECT ns.person_id, ns.item_num, ns.value_num, ns.value_unit_source, ns.observation_date
-    FROM dbo.naaccr_staging ns
-    WHERE ns.value_num IS NOT NULL
-  )
+-- All NAACCR items → Measurements (numeric -> value_as_number; coded -> value_as_concept_id)
 INSERT INTO dbo.measurement
   (
   person_id, measurement_concept_id, measurement_date, measurement_datetime,
   measurement_type_concept_id, operator_concept_id, value_as_number, value_as_concept_id,
   unit_concept_id, range_low, range_high, provider_id, visit_occurrence_id, visit_detail_id,
-  measurement_source_value, measurement_source_concept_id, unit_source_value, value_source_value
+  measurement_source_value, measurement_source_concept_id, unit_source_value, value_source_value,
+  measurement_event_id, meas_event_field_concept_id
   )
 SELECT
   i.person_id,
@@ -201,8 +196,8 @@ SELECT
   @TYPE_NAACCR AS measurement_type_concept_id,
   NULL AS operator_concept_id,
   i.value_num AS value_as_number,
-  NULL AS value_as_concept_id,
-  NULL AS unit_concept_id, -- map when standard units are available
+  vc.value_concept_id AS value_as_concept_id,
+  NULL AS unit_concept_id, -- map unit_source_value to a unit_concept_id if available
   NULL AS range_low,
   NULL AS range_high,
   NULL AS provider_id,
@@ -211,28 +206,33 @@ SELECT
   CAST(i.item_num AS NVARCHAR(50)) AS measurement_source_value,
   ic.item_concept_id AS measurement_source_concept_id,
   i.value_unit_source AS unit_source_value,
-  NULL AS value_source_value
-FROM input_rows_m i
-  JOIN item_concepts_m ic ON ic.item_num = i.item_num;
+  i.value_code AS value_source_value,
+  n.note_id AS measurement_event_id,
+  @FIELD_NOTE_ID AS meas_event_field_concept_id
+FROM input_rows i
+  JOIN item_concepts ic
+  ON ic.item_num = i.item_num
+  LEFT JOIN value_concepts vc
+  ON vc.item_num = i.item_num AND vc.code = COALESCE(i.value_code, N'')
+  LEFT JOIN dbo.note n
+  ON n.person_id = i.person_id AND n.note_source_value = i.episode_key;
 
 ------------------------------------------------------------
--- 3) Link Observations to Episodes via EPISODE_EVENT
+-- 3) Link Measurements to Episodes via EPISODE_EVENT
 ------------------------------------------------------------
 ;WITH
-  obs_with_episode
+  meas_with_episode
   AS
   (
-    SELECT o.observation_id,
-      o.person_id,
+    SELECT m.measurement_id,
+      m.person_id,
       e.episode_id
-    FROM dbo.observation o
+    FROM dbo.measurement m
       JOIN dbo.naaccr_staging ns
-      ON ns.person_id = o.person_id
-        AND CAST(ns.item_num AS NVARCHAR(50)) = o.observation_source_value
-        AND o.observation_date = COALESCE(ns.observation_date, o.observation_date)
+      ON ns.person_id = m.person_id
+        AND CAST(ns.item_num AS NVARCHAR(50)) = m.measurement_source_value
+        AND m.measurement_date = COALESCE(ns.observation_date, m.measurement_date)
       JOIN dbo.episode e
-
-
       ON e.person_id = ns.person_id
         AND e.episode_source_value = ns.episode_key
   )
@@ -240,44 +240,13 @@ INSERT INTO dbo.episode_event
   (
   episode_id, event_id, episode_event_field_concept_id
   )
-SELECT DISTINCT o.episode_id,
-  o.observation_id AS event_id,
-  @FIELD_OBS_ID    AS episode_event_field_concept_id
-FROM obs_with_episode o
-  LEFT JOIN dbo.episode_event ee
-  ON ee.episode_id = o.episode_id
-    AND ee.event_id = o.observation_id
-    AND ee.episode_event_field_concept_id = @FIELD_OBS_ID
-WHERE ee.episode_id IS NULL;
-
-------------------------------------------------------------
--- 4) Link Measurements to Episodes via EPISODE_EVENT
-------------------------------------------------------------
-;
-WITH
-  meas_with_episode
-  AS
-  (
-    SELECT m.measurement_id, m.person_id, e.episode_id
-    FROM dbo.measurement m
-      JOIN dbo.naaccr_staging ns
-      ON ns.person_id = m.person_id
-        AND CAST(ns.item_num AS NVARCHAR(50)) = m.measurement_source_value
-        AND m.measurement_date = COALESCE(ns.observation_date, m.measurement_date)
-      JOIN dbo.episode e
-
-      ON e.person_id = ns.person_id
-        AND e.episode_source_value = ns.episode_key
-  )
-INSERT INTO dbo.episode_event
-  (episode_id, event_id, episode_event_field_concept_id)
-SELECT DISTINCT o.episode_id,
-  o.measurement_id AS event_id,
+SELECT DISTINCT m.episode_id,
+  m.measurement_id AS event_id,
   @FIELD_MEAS_ID   AS episode_event_field_concept_id
-FROM meas_with_episode o
+FROM meas_with_episode m
   LEFT JOIN dbo.episode_event ee
-  ON ee.episode_id = o.episode_id
-    AND ee.event_id = o.measurement_id
+  ON ee.episode_id = m.episode_id
+    AND ee.event_id = m.measurement_id
     AND ee.episode_event_field_concept_id = @FIELD_MEAS_ID
 WHERE ee.episode_id IS NULL;
 

--- a/database/ddl/sqlserver/validate_naaccr_omop_etl.sql
+++ b/database/ddl/sqlserver/validate_naaccr_omop_etl.sql
@@ -1,7 +1,9 @@
 /*
   Validation: NAACCR → OMOP CDM v5.4 ETL Outputs
-  Purpose: Quick post-run checks for episodes, observations, measurements,
+  Purpose: Quick post-run checks for episodes, measurements, the report NOTE,
            and episode_event linkages using dbo.naaccr_staging as source.
+  Note: eCP synoptic Q&A defaults to MEASUREMENT (qualitatively/quantitatively
+        derived). See ECP_OMOP_MAPPING.md.
 */
 
 SET NOCOUNT ON;
@@ -12,11 +14,6 @@ SELECT TOP 1 @EPISODE_TYPE_CANCER = concept_id
 FROM dbo.concept
 WHERE vocabulary_id = 'NAACCR2026' AND concept_code = 'NAACCR_CANCER_EPISODE';
 
-DECLARE @FIELD_OBS_ID BIGINT;
-SELECT TOP 1 @FIELD_OBS_ID = concept_id
-FROM dbo.concept
-WHERE vocabulary_id = 'NAACCR2026' AND concept_code = 'FIELD_OBSERVATION_ID';
-
 DECLARE @FIELD_MEAS_ID BIGINT;
 SELECT TOP 1 @FIELD_MEAS_ID = concept_id
 FROM dbo.concept
@@ -26,6 +23,8 @@ DECLARE @TYPE_NAACCR BIGINT;
 SELECT TOP 1 @TYPE_NAACCR = concept_id
 FROM dbo.concept
 WHERE vocabulary_id = 'NAACCR2026' AND concept_code = 'TYPE_NAACCR_DERIVED';
+
+DECLARE @FIELD_NOTE_ID BIGINT = 1147289; -- note.note_id field concept (TODO confirm)
 
 -----------------------------
 -- 1) Episode counts and coverage
@@ -42,31 +41,32 @@ WHERE e.episode_id IS NULL
 ORDER BY s.person_id, s.episode_key;
 
 -----------------------------
--- 2) Observation/Measurement counts
+-- 2) Measurement counts (ALL staged items become measurements)
 -----------------------------
-SELECT 'Observations: expected vs actual' AS section,
-       (SELECT COUNT(*) FROM dbo.naaccr_staging WHERE value_num IS NULL) AS expected_observations,
-       (SELECT COUNT(*) FROM dbo.observation o WHERE o.observation_type_concept_id = @TYPE_NAACCR) AS actual_observations;
-
 SELECT 'Measurements: expected vs actual' AS section,
-       (SELECT COUNT(*) FROM dbo.naaccr_staging WHERE value_num IS NOT NULL) AS expected_measurements,
+       (SELECT COUNT(*) FROM dbo.naaccr_staging) AS expected_measurements,
        (SELECT COUNT(*) FROM dbo.measurement m WHERE m.measurement_type_concept_id = @TYPE_NAACCR) AS actual_measurements;
 
 -----------------------------
--- 3) Episode_event link checks
+-- 3) Report NOTE checks (one per person/episode) + measurement→note linkage
 -----------------------------
-SELECT 'Episode_event links (obs/meas)' AS section,
-       (SELECT COUNT(*) FROM dbo.episode_event WHERE episode_event_field_concept_id = @FIELD_OBS_ID)  AS obs_links,
+SELECT 'Report notes: expected vs actual' AS section,
+       (SELECT COUNT(*) FROM (SELECT DISTINCT person_id, episode_key FROM dbo.naaccr_staging) s) AS expected_notes,
+       (SELECT COUNT(*) FROM dbo.note) AS actual_notes;
+
+SELECT 'Measurements missing note anchor' AS section,
+       COUNT(*) AS missing_note_anchor
+FROM dbo.measurement m
+WHERE m.measurement_type_concept_id = @TYPE_NAACCR
+  AND (m.measurement_event_id IS NULL OR m.meas_event_field_concept_id <> @FIELD_NOTE_ID);
+
+-----------------------------
+-- 4) Episode_event link checks (measurements)
+-----------------------------
+SELECT 'Episode_event meas links' AS section,
        (SELECT COUNT(*) FROM dbo.episode_event WHERE episode_event_field_concept_id = @FIELD_MEAS_ID) AS meas_links;
 
-SELECT 'Observations missing links' AS section,
-       COUNT(*) AS missing_obs_links
-FROM dbo.observation o
-LEFT JOIN dbo.episode_event ee
-  ON ee.event_id = o.observation_id AND ee.episode_event_field_concept_id = @FIELD_OBS_ID
-WHERE ee.event_id IS NULL;
-
-SELECT 'Measurements missing links' AS section,
+SELECT 'Measurements missing episode links' AS section,
        COUNT(*) AS missing_meas_links
 FROM dbo.measurement m
 LEFT JOIN dbo.episode_event ee
@@ -74,26 +74,24 @@ LEFT JOIN dbo.episode_event ee
 WHERE ee.event_id IS NULL;
 
 -----------------------------
--- 4) Per-episode summary (top 20)
+-- 5) Per-episode summary (top 20)
 -----------------------------
 SELECT TOP 20 'Per episode summary' AS section,
        x.person_id,
        x.episode_source_value,
-       x.obs_count,
        x.meas_count
 FROM (
   SELECT e.person_id,
          e.episode_source_value,
-         COUNT(DISTINCT CASE WHEN ee.episode_event_field_concept_id = @FIELD_OBS_ID  THEN ee.event_id END) AS obs_count,
          COUNT(DISTINCT CASE WHEN ee.episode_event_field_concept_id = @FIELD_MEAS_ID THEN ee.event_id END) AS meas_count
   FROM dbo.episode e
   LEFT JOIN dbo.episode_event ee ON ee.episode_id = e.episode_id
   GROUP BY e.person_id, e.episode_source_value
 ) AS x
-ORDER BY (x.obs_count + x.meas_count) DESC, x.person_id;
+ORDER BY x.meas_count DESC, x.person_id;
 
 -----------------------------
--- 5) Spot check for units (top 20 measurements with unit_source_value)
+-- 6) Spot check for units (top 20 numeric measurements with unit_source_value)
 -----------------------------
 SELECT TOP 20 'Measurement units' AS section,
        m.person_id, m.measurement_source_value, m.value_as_number, m.unit_source_value, m.measurement_date

--- a/database/naaccr_omop/README.md
+++ b/database/naaccr_omop/README.md
@@ -16,7 +16,7 @@ The `omop` branch of this SDC-CDM repo currently implements the working-group
 SQL Server path:
 
 ```text
-dbo.naaccr_staging -> EPISODE -> OBSERVATION / MEASUREMENT -> EPISODE_EVENT
+dbo.naaccr_staging -> EPISODE + NOTE -> MEASUREMENT -> EPISODE_EVENT
 ```
 
 That path is represented by `database/ddl/sqlserver/naaccr_to_omop_etl.sql`
@@ -42,13 +42,16 @@ of committed files.
 The generated spec encodes the rules confirmed in SDC-CDM discussion #77
 from May 27, 2026:
 
-- Pathology and measurement-like NAACCR items, including SSDIs, grades, staging,
-  and constrained pick lists, default to `MEASUREMENT`.
+- eCP synoptic Q&A — pathology items, SSDIs, grades, staging, and constrained
+  pick lists — defaults to `MEASUREMENT`. Each item is a qualitative or quantitative
+  result of a standardized pathology activity (coded answers use `value_as_concept_id`,
+  numeric uses `value_as_number`). Domain-driven routing (read the mapped concept's
+  `domain_id`) is the future refinement. See `ECP_OMOP_MAPPING.md` at the repo root.
 - Demographic, registry-management, confidential, and otherwise NAACCR-specific
   data remains in extension tables unless it maps cleanly to OMOP core.
 - Foreign keys live on the NAACCR extension-table side and point to OMOP records.
 - Do not add non-FK NAACCR fields to OMOP core tables.
-- The preferred direction is CAP to NAACCR to MEASUREMENT.
+- The preferred direction is CAP to NAACCR to OBSERVATION.
 
 Discussion #78 is dated June 3, 2026 and is a future agenda as of June 1, 2026,
 so it is referenced as a planning input rather than as a final decision record.
@@ -128,7 +131,7 @@ and implements:
   `phenoml` SDK;
 - a workflow runner that loads JSON workflow definitions and this mapping spec;
 - a NAACCR XML or V2 to JSON preprocessor;
-- sample execution that emits OMOP 5.4-compatible `episode`,
+- sample execution that emits OMOP 5.4-compatible `episode`, `note`,
   `episode_event`, `measurement`, `observation`, and extension-table rows.
 
 Credentials must not be committed. The PhenoML package should fail loudly with a

--- a/database/naaccr_omop/naaccr_omop_extension_mapping_spec.json
+++ b/database/naaccr_omop/naaccr_omop_extension_mapping_spec.json
@@ -9,7 +9,7 @@
     "workflows_repo_boundary": "PhenoML auth, workflow definitions, and execution harness live under phenoml-workflows/ in this repo. Credentials stay outside committed files."
   },
   "working_group_rules": {
-    "default_target": "Pathology and measurement-like NAACCR items, including SSDIs, grades, staging, and constrained pick lists, default to MEASUREMENT.",
+    "default_target": "eCP synoptic Q&A (pathology items, SSDIs, grades, staging, and constrained pick lists) defaults to MEASUREMENT \u2014 each item is a qualitative or quantitative result of a standardized pathology activity (coded answers use value_as_concept_id, numeric uses value_as_number). Domain-driven routing (read the mapped concept's domain_id) is the future refinement. See ECP_OMOP_MAPPING.md.",
     "extension_table_use": "Demographic, registry-management, confidential, and other NAACCR-specific fields remain in extension tables unless they map cleanly into OMOP core.",
     "foreign_key_policy": "Foreign keys live on the NAACCR extension-table side and point to OMOP records.",
     "omop_core_policy": "Do not add non-FK NAACCR fields to OMOP core tables.",
@@ -11864,11 +11864,11 @@
         "review_status": "unreviewed",
         "reviewer": null,
         "reviewed_at": null,
-        "review_notes": null,
+        "review_notes": "MEASUREMENT+CONDITION_OCCURRENCE combo: confirm OBSERVATION vs CONDITION_OCCURRENCE for the measurement portion (eCP Q&A is OBSERVATION-only).",
         "rationale": null,
         "target_override_table": null,
         "target_override_field": null,
-        "needs_wg_decision": false
+        "needs_wg_decision": true
       },
       {
         "concept_class_id": "CANCER_IDENTIFICATIO",
@@ -12114,11 +12114,11 @@
         "review_status": "unreviewed",
         "reviewer": null,
         "reviewed_at": null,
-        "review_notes": null,
+        "review_notes": "MEASUREMENT+CONDITION_OCCURRENCE combo: confirm OBSERVATION vs CONDITION_OCCURRENCE for the measurement portion (eCP Q&A is OBSERVATION-only).",
         "rationale": null,
         "target_override_table": null,
         "target_override_field": null,
-        "needs_wg_decision": false
+        "needs_wg_decision": true
       },
       {
         "concept_class_id": "CANCER_IDENTIFICATIO",
@@ -12164,11 +12164,11 @@
         "review_status": "unreviewed",
         "reviewer": null,
         "reviewed_at": null,
-        "review_notes": null,
+        "review_notes": "MEASUREMENT+CONDITION_OCCURRENCE combo: confirm OBSERVATION vs CONDITION_OCCURRENCE for the measurement portion (eCP Q&A is OBSERVATION-only).",
         "rationale": null,
         "target_override_table": null,
         "target_override_field": null,
-        "needs_wg_decision": false
+        "needs_wg_decision": true
       },
       {
         "concept_class_id": "CANCER_IDENTIFICATIO",
@@ -12289,11 +12289,11 @@
         "review_status": "unreviewed",
         "reviewer": null,
         "reviewed_at": null,
-        "review_notes": null,
+        "review_notes": "MEASUREMENT+CONDITION_OCCURRENCE combo: confirm OBSERVATION vs CONDITION_OCCURRENCE for the measurement portion (eCP Q&A is OBSERVATION-only).",
         "rationale": null,
         "target_override_table": null,
         "target_override_field": null,
-        "needs_wg_decision": false
+        "needs_wg_decision": true
       },
       {
         "concept_class_id": "CANCER_IDENTIFICATIO",

--- a/phenoml-workflows/phenoml_workflows/mapper.py
+++ b/phenoml-workflows/phenoml_workflows/mapper.py
@@ -4,6 +4,9 @@ from typing import Any, Optional
 
 
 def _normalize_target(mapping: dict[str, Any]) -> str:
+    # eCP synoptic Q&A defaults to MEASUREMENT (qualitatively/quantitatively derived from a
+    # standardized pathology activity). Domain-driven routing sends the Observation-domain
+    # minority to observation; everything else defaults to measurement. See ECP_OMOP_MAPPING.md.
     omop_table = str(mapping.get("omop_table") or "").lower()
     mapping_kind = str(mapping.get("mapping_kind") or "").lower()
 
@@ -44,6 +47,34 @@ def _value_source_value(item: dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _note_row(
+    *,
+    row_id: int,
+    source: dict[str, Any],
+    workflow: dict[str, Any],
+) -> dict[str, Any]:
+    # One NOTE per synoptic report; measurements reference it via measurement_event_id.
+    constants = workflow.get("constants", {})
+    report = source.get("report", {})
+    return {
+        "note_id": row_id,
+        "person_id": source["person"]["person_id"],
+        "note_date": _row_date({}, source),
+        "note_datetime": None,
+        "note_type_concept_id": constants.get("note_type_concept_id", 32817),  # EHR
+        "note_class_concept_id": constants.get("note_class_concept_id", 0),  # TODO: map synoptic report LOINC
+        "note_title": report.get("title") or "Synoptic Report",
+        "note_text": report.get("text") or "Synoptic report",
+        "encoding_concept_id": constants.get("encoding_concept_id", 0),
+        "language_concept_id": constants.get("language_concept_id", 0),
+        "provider_id": None,
+        "visit_occurrence_id": None,
+        "note_source_value": report.get("accession"),
+        "note_event_id": None,
+        "note_event_field_concept_id": None,
+    }
+
+
 def _measurement_row(
     *,
     row_id: int,
@@ -51,7 +82,11 @@ def _measurement_row(
     item: dict[str, Any],
     mapping: dict[str, Any],
     workflow: dict[str, Any],
+    note_id: Optional[int] = None,
 ) -> dict[str, Any]:
+    # eCP synoptic Q&A defaults to MEASUREMENT. Numeric -> value_as_number; coded ->
+    # value_as_concept_id; raw answer preserved in value_source_value. measurement_event_id
+    # anchors the row to the report NOTE.
     constants = workflow.get("constants", {})
     return {
         "measurement_id": row_id,
@@ -62,7 +97,7 @@ def _measurement_row(
         "measurement_type_concept_id": constants.get("measurement_type_concept_id", 0),
         "operator_concept_id": None,
         "value_as_number": item.get("value_num"),
-        "value_as_concept_id": None,
+        "value_as_concept_id": None,  # TODO: map coded (CWE) answer to concept id
         "unit_concept_id": None,
         "range_low": None,
         "range_high": None,
@@ -73,6 +108,10 @@ def _measurement_row(
         "measurement_source_concept_id": mapping.get("concept_id"),
         "unit_source_value": item.get("unit_source_value"),
         "value_source_value": _value_source_value(item),
+        "measurement_event_id": note_id,
+        "meas_event_field_concept_id": (
+            constants.get("field_note_id", 1147289) if note_id is not None else None
+        ),
     }
 
 
@@ -83,6 +122,7 @@ def _observation_row(
     item: dict[str, Any],
     mapping: dict[str, Any],
     workflow: dict[str, Any],
+    note_id: Optional[int] = None,
 ) -> dict[str, Any]:
     constants = workflow.get("constants", {})
     value = item.get("value")
@@ -93,9 +133,10 @@ def _observation_row(
         "observation_date": _row_date(item, source),
         "observation_datetime": None,
         "observation_type_concept_id": constants.get("observation_type_concept_id", 0),
+        # Numeric eCP answers use observation.value_as_number (no measurement table).
         "value_as_number": item.get("value_num"),
         "value_as_string": str(value) if value is not None else None,
-        "value_as_concept_id": None,
+        "value_as_concept_id": None,  # TODO: map coded (CWE) answer to concept id
         "qualifier_concept_id": None,
         "unit_concept_id": None,
         "provider_id": None,
@@ -105,6 +146,11 @@ def _observation_row(
         "observation_source_concept_id": mapping.get("concept_id"),
         "unit_source_value": item.get("unit_source_value"),
         "qualifier_source_value": item.get("value_code"),
+        # Single synoptic-report anchor: point at the report's NOTE row.
+        "observation_event_id": note_id,
+        "obs_event_field_concept_id": (
+            constants.get("field_note_id", 1147289) if note_id is not None else None
+        ),
     }
 
 
@@ -163,8 +209,12 @@ def map_naaccr_case_to_omop(
     workflow: dict[str, Any],
 ) -> dict[str, Any]:
     mappings = _index_mappings(mapping_spec)
+    # One NOTE per synoptic report; measurements (and any observations) reference it.
+    note_id = source.get("id_offsets", {}).get("note_id", 1)
+    note = _note_row(row_id=note_id, source=source, workflow=workflow)
     rows: dict[str, Any] = {
         "episode": [_episode_row(source, workflow)],
+        "note": [note],
         "measurement": [],
         "observation": [],
         "episode_event": [],
@@ -185,6 +235,12 @@ def map_naaccr_case_to_omop(
         _add_extension_value(rows=rows, source=source, mapping=mapping, item=item)
         target = _normalize_target(mapping)
 
+        # omop_core/extension items are written elsewhere.
+        if target in {"omop_core", "extension_only"}:
+            continue
+
+        # Domain-driven: Observation-domain minority -> observation; everything else
+        # (the eCP default) -> measurement. Both anchor to the report NOTE.
         if target == "observation":
             observation = _observation_row(
                 row_id=observation_id,
@@ -192,6 +248,7 @@ def map_naaccr_case_to_omop(
                 item=item,
                 mapping=mapping,
                 workflow=workflow,
+                note_id=note["note_id"],
             )
             observation_id += 1
             rows["observation"].append(observation)
@@ -206,15 +263,13 @@ def map_naaccr_case_to_omop(
             )
             continue
 
-        if target in {"omop_core", "extension_only"}:
-            continue
-
         measurement = _measurement_row(
             row_id=measurement_id,
             source=source,
             item=item,
             mapping=mapping,
             workflow=workflow,
+            note_id=note["note_id"],
         )
         measurement_id += 1
         rows["measurement"].append(measurement)

--- a/phenoml-workflows/sample/naaccr-case.example.json
+++ b/phenoml-workflows/sample/naaccr-case.example.json
@@ -10,6 +10,12 @@
     "episode_start_date": "2024-01-15",
     "episode_end_date": null
   },
+  "report": {
+    "accession": "15SL-2",
+    "loinc": "60568-3",
+    "title": "Synoptic Report ADRENAL GLAND",
+    "text": "Synoptic report for adrenal gland resection (sample)."
+  },
   "observation_date": "2024-01-15",
   "items": [
     {

--- a/phenoml-workflows/workflows/naaccr-to-omop.workflow.json
+++ b/phenoml-workflows/workflows/naaccr-to-omop.workflow.json
@@ -10,8 +10,13 @@
     "episode_type_concept_id": 0,
     "measurement_type_concept_id": 0,
     "observation_type_concept_id": 0,
+    "note_type_concept_id": 32817,
+    "note_class_concept_id": 0,
+    "encoding_concept_id": 0,
+    "language_concept_id": 0,
     "field_measurement_id": 1147138,
-    "field_observation_id": 1147165
+    "field_observation_id": 1147165,
+    "field_note_id": 1147289
   },
   "rules": {
     "default_naaccr_target": "measurement",
@@ -35,6 +40,11 @@
       "table": "episode"
     },
     {
+      "id": "build_report_note",
+      "type": "emit",
+      "table": "note"
+    },
+    {
       "id": "map_case_items",
       "type": "map_items",
       "item_key": "concept_code",
@@ -48,6 +58,7 @@
   ],
   "outputs": [
     "episode",
+    "note",
     "measurement",
     "observation",
     "episode_event",

--- a/sample_data/ecp_query_examples.sql
+++ b/sample_data/ecp_query_examples.sql
@@ -1,8 +1,10 @@
 -- ECP Data Query Examples
--- This file contains example SQL queries for the OMOP SDC MVP ECP data
+-- eCP synoptic Q&A defaults to MEASUREMENT (qualitatively/quantitatively derived).
+-- See ECP_OMOP_MAPPING.md. These examples use the PostgreSQL-style denormalized sdc_*
+-- columns on measurement; SQLite links via sdc_form_answer.
 
 -- 1. How many lung cancer patients were diagnosed in California in 2024?
-SELECT 
+SELECT
     COUNT(DISTINCT m.person_id) as patient_count
 FROM measurement m
 JOIN person p ON m.person_id = p.person_id
@@ -12,7 +14,7 @@ WHERE m.sdc_question_identifier LIKE '%820603%'  -- Procedure field
   AND m.measurement_date <= '2024-12-31';
 
 -- 2. Show all ECP data for a specific template version
-SELECT 
+SELECT
     m.measurement_id,
     m.person_id,
     m.sdc_question_identifier,
@@ -28,7 +30,7 @@ WHERE m.sdc_template_version = '3.007.011.1000043'
 ORDER BY m.sdc_order;
 
 -- 3. Find patients with specific tumor characteristics
-SELECT 
+SELECT
     p.person_id,
     p.person_source_value,
     m_tumor.sdc_response_value as tumor_size,
@@ -46,7 +48,7 @@ WHERE m_tumor.sdc_question_identifier LIKE '%2129%'  -- Tumor Size
   AND m_tumor.sdc_template_instance_guid = m_margin.sdc_template_instance_guid;
 
 -- 4. Get all template instances for a specific template
-SELECT 
+SELECT
     ecp.sdc_template_instance_ecp_id,
     ecp.template_name,
     ecp.template_version,
@@ -63,15 +65,16 @@ GROUP BY ecp.sdc_template_instance_ecp_id
 ORDER BY ecp.created_datetime DESC;
 
 -- 5. Query both vanilla OMOP fields and SDC-specific columns
-SELECT 
+SELECT
     p.person_id,
     p.person_source_value,
     p.year_of_birth,
     p.gender_source_value,
     m.measurement_date,
     m.measurement_source_value,
-    m.value_as_number,
-    m.value_as_string,
+    m.value_as_number,    -- numeric answers (e.g. tumor size, organ weight)
+    m.value_as_concept_id, -- coded answer concept (when vocabulary mapped)
+    m.value_source_value,  -- raw / human-readable answer
     m.unit_source_value,
     -- SDC-specific fields
     m.sdc_template_instance_guid,
@@ -89,7 +92,7 @@ WHERE m.sdc_template_instance_guid IS NOT NULL
 ORDER BY p.person_id, m.sdc_order;
 
 -- 6. Find all measurements for a specific template instance
-SELECT 
+SELECT
     m.sdc_question_identifier,
     m.sdc_question_text,
     m.sdc_response_value,
@@ -103,12 +106,14 @@ WHERE m.sdc_template_instance_guid = 'your-template-instance-guid-here'
 ORDER BY m.sdc_order;
 
 -- 7. Get template metadata for a specific instance
-SELECT 
+SELECT
     ecp.template_name,
     ecp.template_version,
     ecp.report_template_source,
     ecp.report_template_id,
     ecp.report_template_version_id,
+    ecp.report_accession,
+    ecp.report_loinc,
     ecp.tumor_site,
     ecp.procedure_type,
     ecp.specimen_laterality,
@@ -117,7 +122,7 @@ FROM sdc_template_instance_ecp ecp
 WHERE ecp.template_instance_guid = 'your-template-instance-guid-here';
 
 -- 8. Count measurements by response type
-SELECT 
+SELECT
     m.sdc_response_type,
     COUNT(*) as count
 FROM measurement m
@@ -126,7 +131,7 @@ GROUP BY m.sdc_response_type
 ORDER BY count DESC;
 
 -- 9. Find patients with adrenal gland procedures
-SELECT 
+SELECT
     p.person_id,
     p.person_source_value,
     ecp.template_name,
@@ -140,19 +145,29 @@ WHERE ecp.template_name LIKE '%ADRENAL%'
   AND ecp.procedure_type IS NOT NULL
 ORDER BY ecp.created_datetime DESC;
 
--- 10. Get all template instances with their measurement counts
-SELECT 
-    ecp.template_name,
-    ecp.template_version,
-    COUNT(DISTINCT ecp.sdc_template_instance_ecp_id) as instance_count,
-    COUNT(m.measurement_id) as total_measurements,
-    AVG(measurement_count) as avg_measurements_per_instance
+-- 10. Retrieve a whole synoptic report via its NOTE anchor.
+--     Every measurement from a report shares one measurement_event_id = note.note_id.
+SELECT
+    n.note_id,
+    n.note_source_value AS report_accession,
+    m.sdc_question_text,
+    m.value_as_number,
+    m.value_as_concept_id,
+    m.value_source_value,
+    m.sdc_order
+FROM note n
+JOIN measurement m
+  ON m.measurement_event_id = n.note_id
+ AND m.meas_event_field_concept_id = 1147289   -- note.note_id field concept
+ORDER BY n.note_id, m.sdc_order;
+
+-- 11. Flagged duplicate synoptic reports (same OBR accession re-imported).
+--     Re-imports are never deduped; they are inserted and flagged.
+SELECT
+    ecp.sdc_template_instance_ecp_id,
+    ecp.report_accession,
+    ecp.first_seen_ecp_id,
+    ecp.created_datetime
 FROM sdc_template_instance_ecp ecp
-LEFT JOIN (
-    SELECT sdc_template_instance_guid, COUNT(*) as measurement_count
-    FROM measurement 
-    WHERE sdc_template_instance_guid IS NOT NULL
-    GROUP BY sdc_template_instance_guid
-) m ON ecp.template_instance_guid = m.sdc_template_instance_guid
-GROUP BY ecp.template_name, ecp.template_version
-ORDER BY instance_count DESC;
+WHERE ecp.is_duplicate_accession = 1
+ORDER BY ecp.report_accession, ecp.created_datetime;

--- a/tools/convert_naaccr_omop_maps.py
+++ b/tools/convert_naaccr_omop_maps.py
@@ -502,8 +502,12 @@ def build_spec(input_dir: Path, existing_spec: dict[str, Any] | None = None) -> 
         },
         "working_group_rules": {
             "default_target": (
-                "Pathology and measurement-like NAACCR items, including SSDIs, "
-                "grades, staging, and constrained pick lists, default to MEASUREMENT."
+                "eCP synoptic Q&A (pathology items, SSDIs, grades, staging, and "
+                "constrained pick lists) defaults to MEASUREMENT — each item is a "
+                "qualitative or quantitative result of a standardized pathology "
+                "activity (coded answers use value_as_concept_id, numeric uses "
+                "value_as_number). Domain-driven routing (read the mapped concept's "
+                "domain_id) is the future refinement. See ECP_OMOP_MAPPING.md."
             ),
             "extension_table_use": (
                 "Demographic, registry-management, confidential, and other "


### PR DESCRIPTION
eCP/SDC form answers default to OMOP measurement (qualitative/quantitative
results of a standardized pathology activity); see ECP_OMOP_MAPPING.md.
Coded->value_as_concept_id(+value_source_value), numeric->value_as_number,
text->value_source_value. One OMOP note per synoptic report; measurements
link via measurement_event_id; OBR accession captured; duplicate accessions
flagged; OBX-4 sub-answers grouped via sdc_form_answer.parent_form_answer_id.
Spans C# importer, SQLite/PostgreSQL DDL, SQL Server ETL, PhenoML mapper,
mapping-spec converter (+regenerated spec), docs and query examples. Adds
design docs SCHEMA_ARCHITECTURE.md and ECP_CONCEPT_MAPPING_SCOPE.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
